### PR TITLE
Updating package.json to Platform2

### DIFF
--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@BookerSoftwareInc/ultradns",
+    "name": "@mb-platform2/ultradns",
     "version": "${VERSION}",
     "description": "A Pulumi package for creating and managing ultradns cloud resources.",
     "keywords": [


### PR DESCRIPTION
- Switching from booker name to `mb-platform2` for our NPM registry ORG